### PR TITLE
ChatRoomParticipant와 Message의 필드 변경 + Repository method 추가

### DIFF
--- a/src/main/java/com/example/teamrocket/chatRoom/domain/ChatRoomParticipantDto.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/domain/ChatRoomParticipantDto.java
@@ -1,6 +1,7 @@
 package com.example.teamrocket.chatRoom.domain;
 
 import com.example.teamrocket.chatRoom.entity.mysql.ChatRoomParticipant;
+import com.example.teamrocket.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +17,13 @@ public class ChatRoomParticipantDto {
     private String profileImage;
 
     public static ChatRoomParticipantDto of(ChatRoomParticipant participant){
+        User user = participant.getUser();
+
         return ChatRoomParticipantDto.builder()
-                .userId(participant.getUserId())
+                .userId(user.getId())
                 .isOwner(participant.isOwner())
-                .nickname(participant.getNickname())
-                .profileImage(participant.getProfileImage())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
                 .build();
     }
 }

--- a/src/main/java/com/example/teamrocket/chatRoom/domain/MessageDto.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/domain/MessageDto.java
@@ -13,15 +13,13 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class MessageDto {
-    private String senderName;
-    private String senderImgSrc;
+    private Long userId;
     private String message;
     private LocalDateTime createdAt;
 
     public static MessageDto of(Message message){
         return MessageDto.builder()
-                .senderName(message.getSenderName())
-                .senderImgSrc(message.getSenderImgSrc())
+                .userId(message.getUserId())
                 .message(message.getMessage())
                 .createdAt(message.getCreatedAt()).build();
     }

--- a/src/main/java/com/example/teamrocket/chatRoom/entity/Message.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/entity/Message.java
@@ -23,8 +23,7 @@ public class Message implements Serializable {
     private String id;
 
     private String roomId;
-    private String senderName;
-    private String senderImgSrc;
+    private Long userId;
     private String message;
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/teamrocket/chatRoom/entity/mysql/ChatRoomParticipant.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/entity/mysql/ChatRoomParticipant.java
@@ -1,6 +1,7 @@
 package com.example.teamrocket.chatRoom.entity.mysql;
 
 import com.example.teamrocket.config.jpa.BaseEntity;
+import com.example.teamrocket.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,8 +25,9 @@ public class ChatRoomParticipant extends BaseEntity {
     @JoinColumn(name = "chat_id")
     private ChatRoomMySql chatRoomMySql;
 
-    private Long userId;
     private boolean isOwner;
-    private String nickname;
-    private String profileImage;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
 }

--- a/src/main/java/com/example/teamrocket/chatRoom/repository/mysql/ChatRoomMySqlRepository.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/repository/mysql/ChatRoomMySqlRepository.java
@@ -1,6 +1,7 @@
 package com.example.teamrocket.chatRoom.repository.mysql;
 
 import com.example.teamrocket.chatRoom.entity.mysql.ChatRoomMySql;
+import com.example.teamrocket.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,15 +9,20 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.sql.Date;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomMySqlRepository extends JpaRepository<ChatRoomMySql,String> {
     Page<ChatRoomMySql> findAllByRcate1AndRcate2AndDeletedAtIsNullAndEndDateAfterOrderByStartDate(String rcate1, String rcate2, LocalDate date, Pageable pageable);
     Optional<ChatRoomMySql> findByIdAndDeletedAtIsNullAndEndDateAfter(String id,LocalDate date);
+
+    @Query(value = "SELECT c FROM ChatRoomMySql c " +
+            "join ChatRoomParticipant participant on (participant.chatRoomMySql.id=c.id and participant.user = :user ) " +
+            "where c.deletedAt IS NULL AND c.endDate> :date " +
+            "order by c.startDate")
+    Page<ChatRoomMySql> findAllByUserIdAndAndDeletedAtIsNullAndEndDateAfterOrderByStartDate(User user, LocalDate date, Pageable pageable);
+
     @Query(
             value = "SELECT * FROM chat c where c.end_date < ?1 limit 1000",
             nativeQuery = true

--- a/src/main/java/com/example/teamrocket/chatRoom/repository/redis/RedisTemplateRepository.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/repository/redis/RedisTemplateRepository.java
@@ -23,7 +23,7 @@ public class RedisTemplateRepository {
     private RedisTemplate<String, Message> redisTemplate;
     public void setExpireDateOnRoom(String roomId, LocalDateTime endDate){
         Message welcome = Message.builder()
-                .senderName("TeamRocket")
+                .userId(1L)
                 .message("Welcome !")
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/example/teamrocket/controller/RabbitChatController.java
+++ b/src/main/java/com/example/teamrocket/controller/RabbitChatController.java
@@ -20,10 +20,11 @@ public class RabbitChatController {
     private final RabbitTemplate template;
     private final String CHAT_EXCHANGE_NAME = "chat.exchange";
     private final RedisTemplateRepository redisTemplateRepository;
+    private final Long systemUserId = 666L;
 
     @MessageMapping("chat.enter.{roomId}.{nickname}")
     public void enterMessage(@DestinationVariable String roomId,@DestinationVariable String nickname){
-        Message message = Message.builder().senderName("system"+roomId).build();
+        Message message = Message.builder().userId(systemUserId).build();
         message.updateMessage(nickname + "님이 채팅방에 참여하였습니다.");
 
         message.updateRoomIdAndCreatedAt(roomId);
@@ -39,7 +40,7 @@ public class RabbitChatController {
 
     @MessageMapping("chat.leave.{roomId}.{nickname}")
     public void leaveMessage(@DestinationVariable String roomId,@DestinationVariable String nickname){
-        Message message = Message.builder().senderName("system"+roomId).build();
+        Message message = Message.builder().userId(systemUserId).build();
         message.updateRoomIdAndCreatedAt(roomId);
         message.updateMessage(nickname + "님이 채팅방에서 나가셨습니다.");
         template.convertAndSend(CHAT_EXCHANGE_NAME,"room."+roomId,message);

--- a/src/main/java/com/example/teamrocket/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/teamrocket/service/ChatServiceImpl.java
@@ -101,17 +101,12 @@ public class ChatServiceImpl implements ChatService{
         User user = userRepository.findByUuid(commonRequestContext.getMemberUuId()).orElseThrow(
                 ()->new UserException(USER_NOT_FOUND));
 
-        Page<ChatRoomParticipant> participantPage =
-                chatRoomParticipantRepository.findAllByUserId(user.getId(), pageRequest);
-
         Page<ChatRoomMySql> chatRoomPage =
-                participantPage.map(ChatRoomParticipant::getChatRoomMySql);
+                chatRoomMySqlRepository
+                        .findAllByUserIdAndAndDeletedAtIsNullAndEndDateAfterOrderByStartDate(user, LocalDate.now().minusDays(1),pageRequest);
 
         List<ChatRoomDto> contents = new ArrayList<>(chatRoomPage.getContent().size());
         for(ChatRoomMySql chatRoom:chatRoomPage.getContent()){
-            if(chatRoom.getEndDate().isBefore(LocalDate.now()) || chatRoom.getDeletedAt() != null){
-                continue;
-            }
             ChatRoomDto chatRoomDto = ChatRoomDto.of(chatRoom);
             chatRoomDto.setCurParticipant(chatRoom.getParticipants().size());
 

--- a/src/test/java/com/example/teamrocket/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/teamrocket/controller/ChatControllerTest.java
@@ -762,7 +762,7 @@ public class ChatControllerTest {
         doThrow(new ChatRoomException(CHAT_ROOM_NOT_FOUND))
                 .when(chatService).getRoomInfo(eq("1번방"));
 
-        mockMvc.perform(get("/api/v1/chat/room/1번방/participants"))
+        mockMvc.perform(get("/api/v1/chat/room/info/1번방"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.result").isEmpty())

--- a/src/test/java/com/example/teamrocket/dbTest/DbConnectionSaveTest.java
+++ b/src/test/java/com/example/teamrocket/dbTest/DbConnectionSaveTest.java
@@ -47,14 +47,14 @@ public class DbConnectionSaveTest {
     void saveRedisTest() throws Exception{
         String roomId = "roomIdTest";
         Message m1 = Message.builder()
-                .senderName("로사")
+                .userId(1L)
                 .message("우리가 누군지 물으신다면 나 로사")
                 .createdAt(LocalDateTime.now())
                 .build();
         redisTemplateRepository.saveToLeft(roomId,m1);
 
         Message m2 = Message.builder()
-                .senderName("로이")
+                .userId(1L)
                 .message("나 로이")
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/example/teamrocket/dbTest/MongodbTest.java
+++ b/src/test/java/com/example/teamrocket/dbTest/MongodbTest.java
@@ -3,9 +3,7 @@ package com.example.teamrocket.dbTest;
 import com.example.teamrocket.chatRoom.entity.ChatRoom;
 import com.example.teamrocket.chatRoom.entity.DayOfMessages;
 import com.example.teamrocket.chatRoom.entity.Message;
-import org.assertj.core.api.Assertions;
 import org.bson.Document;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +19,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @SpringBootTest
@@ -62,7 +60,7 @@ public class MongodbTest {
         for (int i = 0; i < 4; i++) {
             Message m = Message.builder()
                     .message("HolyMoly "+i)
-                    .senderName("abc "+i)
+                    .userId(1L)
                     .createdAt(LocalDateTime.now())
                     .build();
             mongoTemplate.save(m);

--- a/src/test/java/com/example/teamrocket/dbTest/RedisTest.java
+++ b/src/test/java/com/example/teamrocket/dbTest/RedisTest.java
@@ -3,18 +3,14 @@ package com.example.teamrocket.dbTest;
 import com.example.teamrocket.chatRoom.domain.ChatRoomEditInput;
 import com.example.teamrocket.chatRoom.entity.Message;
 import com.example.teamrocket.chatRoom.repository.redis.RedisTemplateRepository;
-import com.example.teamrocket.config.rabbit.RabbitConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
-import org.springframework.web.socket.config.annotation.EnableWebSocket;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -51,7 +47,7 @@ public class RedisTest {
     public void test() throws Exception{
         String roomId = "abcd";
         Message build = Message.builder()
-                .senderName("holy")
+                .userId(3L)
                 .build();
 
         ChatRoomEditInput build1 = ChatRoomEditInput.builder()
@@ -67,7 +63,7 @@ public class RedisTest {
     @DisplayName("redis expire date init")
     public void redisInitExpireDateTest() throws Exception{
         Message build = Message.builder()
-                .senderName("TeamRocket")
+                .userId(2L)
                 .message("Welcome Message")
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -91,7 +87,7 @@ public class RedisTest {
         int sizeTest = 100;
         for (int i = 0; i < sizeTest; i++) {
             Message build = Message.builder()
-                    .senderName("TeamRocket")
+                    .userId(3L)
                     .message("Welcome Message" + i)
                     .createdAt(LocalDateTime.now())
                     .build();
@@ -134,7 +130,7 @@ public class RedisTest {
             List<Message> messages = new ArrayList<>();
             for(int i=0; i<Integer.parseInt(substring)*100;i++){
                 messages.add(Message.builder()
-                        .senderName("SomePerson")
+                                .userId(5L)
                         .message("Test Message "+ i)
                         .build());
             }

--- a/src/test/java/com/example/teamrocket/scheulde/ChatDeleteTest.java
+++ b/src/test/java/com/example/teamrocket/scheulde/ChatDeleteTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -183,7 +182,7 @@ public class ChatDeleteTest {
             ChatRoomParticipant chatRoomParticipant =
                     ChatRoomParticipant.builder()
                             .chatRoomMySql(save)
-                            .userId(list.get(i).getId())
+                            .user(list.get(i))
                             .build();
             list2.add(chatRoomParticipant);
         }

--- a/src/test/java/com/example/teamrocket/service/ChatServiceTest.java
+++ b/src/test/java/com/example/teamrocket/service/ChatServiceTest.java
@@ -98,9 +98,8 @@ class ChatServiceTest {
 
         verify(chatRoomParticipantRepository,times(1)).save(participantCaptor.capture());
         ChatRoomParticipant chatRoomParticipantCaptured = participantCaptor.getValue();
-        assertEquals(1L,chatRoomParticipantCaptured.getUserId());
         assertEquals(chatRoomMySqlCaptured,chatRoomParticipantCaptured.getChatRoomMySql());
-        assertEquals(1L,chatRoomParticipantCaptured.getUserId());
+        assertEquals(1L,chatRoomParticipantCaptured.getUser().getId());
         assertTrue(chatRoomParticipantCaptured.isOwner());
 
     }
@@ -202,26 +201,24 @@ class ChatServiceTest {
     void myListRoomSuccess() {
         //given
         User user1 = User.builder().id(1L).profileImage("프로필 이미지 경로1").nickname("닉네임1").build();
-        User user2 = User.builder().id(1L).profileImage("프로필 이미지 경로2").nickname("닉네임2").build();
-        User user3 = User.builder().id(1L).profileImage("프로필 이미지 경로3").nickname("닉네임3").build();
 
         ChatRoomMySql room1 = ChatRoomMySql.builder()
                 .title("채팅방1").rcate1("서울시").owner(user1).endDate(LocalDate.now().plusDays(3)).participants(new ArrayList<>()).build();
         ChatRoomMySql room2 = ChatRoomMySql.builder()
-                .title("채팅방2").rcate1("서울시").owner(user2).endDate(LocalDate.now().plusDays(3)).participants(new ArrayList<>()).build();
+                .title("채팅방2").rcate1("서울시").owner(user1).endDate(LocalDate.now().plusDays(3)).participants(new ArrayList<>()).build();
         ChatRoomMySql room3 = ChatRoomMySql.builder()
-                .title("채팅방3").rcate1("서울시").owner(user3).endDate(LocalDate.now().plusDays(3)).participants(new ArrayList<>()).build();
+                .title("채팅방3").rcate1("서울시").owner(user1).endDate(LocalDate.now().plusDays(3)).participants(new ArrayList<>()).build();
 
         List<ChatRoomParticipant> participants = new ArrayList<>();
 
         ChatRoomParticipant participant1 = ChatRoomParticipant.builder()
-                        .chatRoomMySql(room1).userId(1L).build();
+                        .chatRoomMySql(room1).user(user1).build();
 
         ChatRoomParticipant participant2 = ChatRoomParticipant.builder()
-                .chatRoomMySql(room2).userId(1L).build();
+                .chatRoomMySql(room2).user(user1).build();
 
         ChatRoomParticipant participant3 = ChatRoomParticipant.builder()
-                .chatRoomMySql(room3).userId(1L).build();
+                .chatRoomMySql(room3).user(user1).build();
 
         participants.add(participant1);
         participants.add(participant2);
@@ -248,8 +245,8 @@ class ChatServiceTest {
 
         assertEquals("채팅방2",results.getContent().get(1).getTitle());
         assertEquals(0,results.getContent().get(1).getCurParticipant());
-        assertEquals("프로필 이미지 경로2",results.getContent().get(1).getOwnerProfileImage());
-        assertEquals("닉네임2",results.getContent().get(1).getOwnerNickName());
+        assertEquals("프로필 이미지 경로1",results.getContent().get(1).getOwnerProfileImage());
+        assertEquals("닉네임1",results.getContent().get(1).getOwnerNickName());
     }
 
     @Test
@@ -480,7 +477,7 @@ class ChatServiceTest {
         verify(chatRoomParticipantRepository,times(1)).save(captor.capture());
         ChatRoomParticipant chatRoomParticipantCaptured = captor.getValue();
         assertEquals(chatRoom,chatRoomParticipantCaptured.getChatRoomMySql());
-        assertEquals(3L,chatRoomParticipantCaptured.getUserId());
+        assertEquals(3L,chatRoomParticipantCaptured.getUser().getId());
         assertFalse(chatRoomParticipantCaptured.isOwner());
         assertEquals(chatRoom.getId(),result.getChatRoomId());
         assertEquals(3L,result.getUserId());
@@ -495,7 +492,7 @@ class ChatServiceTest {
         given(userRepository.findByUuid("uuid")).willReturn(Optional.of(user));
 
         List<ChatRoomParticipant> participants = new ArrayList<>();
-        participants.add(ChatRoomParticipant.builder().userId(3L).build());
+        participants.add(ChatRoomParticipant.builder().user(user).build());
         ChatRoomMySql chatRoom = ChatRoomMySql.builder().id("1번방").participants(participants)
                 .maxParticipant(3)
                 .build();
@@ -520,11 +517,11 @@ class ChatServiceTest {
 
         List<ChatRoomParticipant> participants = new ArrayList<>();
 
-        ChatRoomParticipant participant1 = ChatRoomParticipant.builder().userId(1L)
+        ChatRoomParticipant participant1 = ChatRoomParticipant.builder().user(User.builder().id(1L).build())
                 .build();
         participants.add(participant1);
 
-        ChatRoomParticipant participant2 = ChatRoomParticipant.builder().userId(2L)
+        ChatRoomParticipant participant2 = ChatRoomParticipant.builder().user(User.builder().id(1L).build())
                 .build();
         participants.add(participant2);
 
@@ -554,7 +551,7 @@ class ChatServiceTest {
                 .build();
 
 
-        ChatRoomParticipant participant1 = ChatRoomParticipant.builder().userId(1L)
+        ChatRoomParticipant participant1 = ChatRoomParticipant.builder().user(User.builder().id(1L).build())
                 .chatRoomMySql(chatRoom).build();
 
         given(chatRoomMySqlRepository.findByIdAndDeletedAtIsNullAndEndDateAfter("1번방",LocalDate.now().minusDays(1))).willReturn(
@@ -570,7 +567,7 @@ class ChatServiceTest {
         //then
         verify(chatRoomParticipantRepository,times(1)).delete(captor.capture());
         ChatRoomParticipant capturedChatRoomParticipant = captor.getValue();
-        assertEquals(1L,capturedChatRoomParticipant.getUserId());
+        assertEquals(1L,capturedChatRoomParticipant.getUser().getId());
         assertEquals("1번방",capturedChatRoomParticipant.getChatRoomMySql().getId());
     }
 
@@ -623,7 +620,7 @@ class ChatServiceTest {
         ChatRoomMySql chatRoomMySql = ChatRoomMySql.builder().id("1번방").build();
         
         ChatRoomParticipant participant1 = ChatRoomParticipant.builder()
-                .userId(1L).chatRoomMySql(chatRoomMySql).build();
+                .user(User.builder().id(1L).build()).chatRoomMySql(chatRoomMySql).build();
 
         List<Message> messages = new ArrayList<>();
 
@@ -709,15 +706,15 @@ class ChatServiceTest {
         List<ChatRoomParticipant> participants = new ArrayList<>();
 
         ChatRoomParticipant participant1 = ChatRoomParticipant.builder()
-                .userId(1L).isOwner(true).build();
+                .user(User.builder().id(1L).build()).isOwner(true).build();
         participants.add(participant1);
 
         ChatRoomParticipant participant2 = ChatRoomParticipant.builder()
-                .userId(2L).isOwner(false).build();
+                .user(User.builder().id(2L).build()).isOwner(false).build();
         participants.add(participant2);
 
         ChatRoomParticipant participant3 = ChatRoomParticipant.builder()
-                .userId(3L).isOwner(false).build();
+                .user(User.builder().id(3L).build()).isOwner(false).build();
         participants.add(participant3);
 
         ChatRoomMySql chatRoomMySql = ChatRoomMySql.builder().id("1번방").title("1번방 제목").participants(participants).build();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
ChatRoomParticipant에  userId, nickname, profileImage 필드 존재
Message와 MessageDto에 SenderNickname, SenderImgSrc 존재


**TO-BE**
ChatRoomParticipant에  User @ManyToOne 연관관계 설정
Message와 MessageDto에 userId로 변경
myListRoom 조건에 맞지 않는 부분을 continue로 넘기지 않고 query에서 해결

### 변경 배경
현재는 각 message에 senderNickname 과 profileImage를 메시지를 보낸 시점에 setting하여 저장하고 있습니다.
이렇게 했을 경우 누군가가 자신의 닉네임과 프로필 사진을 변경했을 경우에 이것이 이전 메시지에 반영되지 않고 제일 큰
문제는 자기 자신이 보낸 메시지인데 닉네임만 바꾸면 나의 메시지가 아닌 것이 되어 버립니다.
그리고 chatRoomParticipant 경우에도 RoomInfo로 불러올 때, 생성되는 시점의 닉네임과 이미지를 계속해서 불러오는 문제가 있고 저희 erd에서도 user에 연관관계를 맺도록 되어 있어서 수정했습니다.
그리고 추가로 system user를 두고 그 user의 id가 있으면 합니다.(굳이 DB에 추가될 필요없이 같은 userID가 생성되지 않기만 하면 됩니다.) 현재는 666으로 일단 만들어서 수정을 했는데 이 부분에 대한 확인이 필요합니다. 


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 