### PR TITLE
Merge getMessage

### DIFF
--- a/src/main/java/com/example/teamrocket/chatRoom/repository/redis/RedisTemplateRepository.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/repository/redis/RedisTemplateRepository.java
@@ -84,4 +84,8 @@ public class RedisTemplateRepository {
     public List<Message> getMessage(String roomId, int page, int size){
         return redisTemplate.opsForList().range(roomId, page *size, ((page + 1) *size)-1);
     }
+
+    public Long getMessageSize(String roomId){
+        return redisTemplate.opsForList().size(roomId);
+    }
 }

--- a/src/main/java/com/example/teamrocket/controller/ChatController.java
+++ b/src/main/java/com/example/teamrocket/controller/ChatController.java
@@ -8,12 +8,10 @@ import com.example.teamrocket.utils.PagingResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.time.LocalDate;
 
 import static com.example.teamrocket.utils.ApiUtils.success;
 
@@ -83,21 +81,10 @@ public class ChatController {
     @GetMapping("/message/{roomId}")
     public ResponseEntity<ApiResult<MessagePagingResponse<MessageDto>>> getMessages(
             @PathVariable String roomId,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
             @RequestParam Integer page, @RequestParam Integer size){
 
-        MessagePagingResponse<MessageDto> messages = chatService.getMessages(roomId,date,page,size);
+        MessagePagingResponse<MessageDto> messages = chatService.getMessages(roomId,page,size);
         log.info("Messages get total "+ messages.getContent().size());
-        return ResponseEntity.ok(success(messages));
-    }
-
-    @GetMapping("/message/mongo/{roomId}")
-    public ResponseEntity<ApiResult<MessagePagingResponse<MessageDto>>> getMessagesMongo(
-            @PathVariable String roomId,
-            @RequestParam Integer page,
-            @RequestParam Integer size){
-
-        MessagePagingResponse<MessageDto> messages = chatService.getMessagesMongo(roomId,page,size);
         return ResponseEntity.ok(success(messages));
     }
 }

--- a/src/main/java/com/example/teamrocket/service/ChatService.java
+++ b/src/main/java/com/example/teamrocket/service/ChatService.java
@@ -6,8 +6,6 @@ import com.example.teamrocket.utils.PagingResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-
 @Service
 public interface ChatService {
     ChatRoomDto createRoom(ChatRoomCreateInput param);
@@ -24,9 +22,7 @@ public interface ChatService {
 
     RoomInfoDto getRoomInfo(String roomId);
 
-    MessagePagingResponse<MessageDto> getMessages(String roomId, LocalDate date, Integer page, Integer size);
-
-    MessagePagingResponse<MessageDto> getMessagesMongo(String roomId,Integer page, Integer size);
+    MessagePagingResponse<MessageDto> getMessages(String roomId,Integer page, Integer size);
 
     PagingResponse<ChatRoomDto> myListRoom(Pageable pageRequest);
 }

--- a/src/main/java/com/example/teamrocket/utils/MessagePagingResponse.java
+++ b/src/main/java/com/example/teamrocket/utils/MessagePagingResponse.java
@@ -43,11 +43,15 @@ public class MessagePagingResponse<MessageDto> {
         this.lastDay = isLastDay;
     }
 
-    public void setFromList(List<MessageDto> list, Integer size,LocalDate targetDay){
+    public void setFromList(List<MessageDto> list, LocalDate targetDay,boolean isFirstPage,Integer size, int totalPage,
+                            int totalElements, int currentPage){
         this.targetDay = targetDay;
-        this.size = size;
-        this.content = list;
+        this.firstPage = isFirstPage;
         this.lastPage = list.size() != size;
-
+        this.targetDayTotalPage = totalPage;
+        this.targetDayTotalElements = totalElements;
+        this.size = size;
+        this.targetDayCurrentPage = currentPage;
+        this.content = list;
     }
 }

--- a/src/test/java/com/example/teamrocket/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/teamrocket/controller/ChatControllerTest.java
@@ -573,91 +573,6 @@ public class ChatControllerTest {
                 .andExpect(jsonPath("$.errorMessage").value(NOT_PARTICIPATED_USER.getMessage()))
                 .andDo(print());
     }
-
-    @Test
-    void getMessagesSuccess() throws Exception{
-
-        MessagePagingResponse response = MessagePagingResponse.builder()
-                .lastDay(false)
-                .targetDay(LocalDate.now())
-                .firstPage(true)
-                .lastPage(false)
-                .targetDayTotalPage(20)
-                .targetDayTotalElements(100)
-                .size(5)
-                .targetDayCurrentPage(0)
-                .content(new ArrayList<>())
-                .build();
-
-        given(chatService.getMessages(eq("1번방"),eq(LocalDate.now()),eq(0),eq(5))).willReturn(
-                response);
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        mockMvc.perform(get("/api/v1/chat/message/1번방?date="+formatter.format(LocalDate.now())+"&page=0&size=5"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.result.lastDay").value(false))
-                .andExpect(jsonPath("$.result.targetDay").isNotEmpty())
-                .andExpect(jsonPath("$.result.firstPage").value(true))
-                .andExpect(jsonPath("$.result.lastPage").value(false))
-                .andExpect(jsonPath("$.result.targetDayTotalPage").value(20))
-                .andExpect(jsonPath("$.result.targetDayTotalElements").value(100))
-                .andExpect(jsonPath("$.result.size").value(5))
-                .andExpect(jsonPath("$.result.targetDayCurrentPage").value(0))
-                .andDo(print());
-    }
-
-    @Test
-    void getMessagesFail_NoUser() throws Exception{
-
-        doThrow(new UserException(USER_NOT_FOUND))
-                .when(chatService).getMessages(eq("1번방"),eq(LocalDate.now()),eq(0),eq(5));
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        mockMvc.perform(get("/api/v1/chat/message/1번방?date="+formatter.format(LocalDate.now())+"&page=0&size=5"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value(USER_NOT_FOUND.getMessage()))
-                .andDo(print());
-    }
-
-    @Test
-    void getMessagesFail_NoChatRoom() throws Exception{
-
-        doThrow(new ChatRoomException(CHAT_ROOM_NOT_FOUND))
-                .when(chatService).getMessages(eq("1번방"),eq(LocalDate.now()),eq(0),eq(5));
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-
-        mockMvc.perform(get("/api/v1/chat/message/1번방?date="+formatter.format(LocalDate.now())+"&page=0&size=5"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value(CHAT_ROOM_NOT_FOUND.getMessage()))
-                .andDo(print());
-    }
-
-    @Test
-    void getMessagesFail_NotParticipatedUser() throws Exception{
-
-        doThrow(new ChatRoomException(NOT_PARTICIPATED_USER))
-                .when(chatService).getMessages(eq("1번방"),eq(LocalDate.now()),eq(0),eq(5));
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-
-        mockMvc.perform(get("/api/v1/chat/message/1번방?date="+formatter.format(LocalDate.now())+"&page=0&size=5"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value(NOT_PARTICIPATED_USER.getMessage()))
-                .andDo(print());
-    }
-
         @Test
     void getMessagesMongoSuccess() throws Exception{
 
@@ -672,10 +587,10 @@ public class ChatControllerTest {
                 .targetDayCurrentPage(0)
                 .content(new ArrayList<>())
                 .build();
-        given(chatService.getMessagesMongo(eq("1번방"),eq(0),eq(5))).willReturn(
+        given(chatService.getMessages(eq("1번방"),eq(0),eq(5))).willReturn(
             response);
 
-        mockMvc.perform(get("/api/v1/chat/message/mongo/1번방?&page=0&size=5"))
+        mockMvc.perform(get("/api/v1/chat/message/1번방?&page=0&size=5"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.result.lastDay").value(false))
@@ -693,9 +608,9 @@ public class ChatControllerTest {
     void getMessagesMongoFail_NoUser() throws Exception{
 
         doThrow(new UserException(USER_NOT_FOUND))
-                .when(chatService).getMessagesMongo(eq("1번방"),eq(0),eq(5));
+                .when(chatService).getMessages(eq("1번방"),eq(0),eq(5));
 
-        mockMvc.perform(get("/api/v1/chat/message/mongo/1번방?&page=0&size=5"))
+        mockMvc.perform(get("/api/v1/chat/message/1번방?&page=0&size=5"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.result").isEmpty())
@@ -707,9 +622,9 @@ public class ChatControllerTest {
     void getMessagesMongoFail_NoChatRoom() throws Exception{
 
         doThrow(new ChatRoomException(CHAT_ROOM_NOT_FOUND))
-                .when(chatService).getMessagesMongo(eq("1번방"),eq(0),eq(5));
+                .when(chatService).getMessages(eq("1번방"),eq(0),eq(5));
 
-        mockMvc.perform(get("/api/v1/chat/message/mongo/1번방?&page=0&size=5"))
+        mockMvc.perform(get("/api/v1/chat/message/1번방?&page=0&size=5"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.result").isEmpty())
@@ -721,9 +636,9 @@ public class ChatControllerTest {
     void getMessagesMongoFail_NotParticipatedUser() throws Exception{
 
         doThrow(new ChatRoomException(NOT_PARTICIPATED_USER))
-                .when(chatService).getMessagesMongo(eq("1번방"),eq(0),eq(5));
+                .when(chatService).getMessages(eq("1번방"),eq(0),eq(5));
 
-        mockMvc.perform(get("/api/v1/chat/message/mongo/1번방?&page=0&size=5"))
+        mockMvc.perform(get("/api/v1/chat/message/1번방?&page=0&size=5"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.result").isEmpty())

--- a/src/test/java/com/example/teamrocket/service/ChatServiceTest.java
+++ b/src/test/java/com/example/teamrocket/service/ChatServiceTest.java
@@ -646,7 +646,7 @@ class ChatServiceTest {
 
 
         //when
-        var results = chatService.getMessages("1번방",LocalDate.now(),0,5);
+        var results = chatService.getMessages("1번방",0,5);
 
         //then
         assertEquals(LocalDate.now(),results.getTargetDay());
@@ -670,7 +670,7 @@ class ChatServiceTest {
         //when
         //then
         try{
-            chatService.getMessages("1번방", LocalDate.now(),10,10);
+            chatService.getMessages("1번방",10,10);
         }catch (Exception e){
             assertEquals(CHAT_ROOM_NOT_FOUND.getMessage(),e.getMessage());
         }
@@ -693,7 +693,7 @@ class ChatServiceTest {
         //when
         //then
         try{
-            chatService.getMessages("1번방", LocalDate.now(),10,10);
+            chatService.getMessages("1번방", 10,10);
         }catch (Exception e){
             assertEquals(NOT_PARTICIPATED_USER.getMessage(),e.getMessage());
         }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
getMessages API 와 getMessagesMongo API 별도 존재

**TO-BE**
getMessages API로 두 API 통일

### 배경
포트폴리오 정리하면서 redis 찾아보다가 size만 불러오는 method를 발견해서 그것을 통해 두 method를 합칠 수 있다는 것을 깨닫고 합쳐서 정리했습니다. service test 는 participant 의 createdAt을 설정할 수 없어서 일단 test 못한 채로 했지만 postman으로 몇가지 시험했을 때는 정상 처리되는 것으로 보입니다. 


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 