### PR TITLE
fix : Message와 MessageDto에 profileImage, senderName 필드 다시 추가

### DIFF
--- a/src/main/java/com/example/teamrocket/chatRoom/domain/MessageDto.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/domain/MessageDto.java
@@ -15,11 +15,15 @@ import java.time.LocalDateTime;
 public class MessageDto {
     private Long userId;
     private String message;
+    private String profileImage;
+    private String senderName;
     private LocalDateTime createdAt;
 
     public static MessageDto of(Message message){
         return MessageDto.builder()
                 .userId(message.getUserId())
+                .profileImage(message.getProfileImage())
+                .senderName(message.getSenderName())
                 .message(message.getMessage())
                 .createdAt(message.getCreatedAt()).build();
     }

--- a/src/main/java/com/example/teamrocket/chatRoom/entity/Message.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/entity/Message.java
@@ -25,6 +25,8 @@ public class Message implements Serializable {
     private String roomId;
     private Long userId;
     private String message;
+    private String profileImage;
+    private String senderName;
     private LocalDateTime createdAt;
 
     public void updateRoomIdAndCreatedAt(String id){


### PR DESCRIPTION
채팅방 소켓에서 이 필드가 없으면 불안하기 때문에 어쩔수 없이 다시 추가

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
Message와 MessageDto에 profileImage, senderName 필드 x

**TO-BE**
Message와 MessageDto에 profileImage, senderName 필드 o

### 배경
소켓이 연결 된 상태에서 pariticipants의 정보를 가져오는 과정이 굉장히 불안정하기 때문에 getMessage는 원래 방법대로 가져오지만 소켓이 연결된 상태에서의 messsage는 messageField 의 정보를 따기로 합의함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 