### PR TITLE
getMessages 오류 fix

### DIFF
--- a/src/main/java/com/example/teamrocket/chatRoom/entity/DayOfMessages.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/entity/DayOfMessages.java
@@ -22,4 +22,8 @@ public class DayOfMessages {
     @DocumentReference
     private List<Message> messages;
     private int messagesCount;
+
+    public void setMessagesCount(int messagesCount){
+        this.messagesCount = messagesCount;
+    }
 }

--- a/src/main/java/com/example/teamrocket/chatRoom/repository/mongo/MessageRepository.java
+++ b/src/main/java/com/example/teamrocket/chatRoom/repository/mongo/MessageRepository.java
@@ -2,14 +2,17 @@ package com.example.teamrocket.chatRoom.repository.mongo;
 
 import com.example.teamrocket.chatRoom.entity.Message;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Repository
 public interface MessageRepository extends MongoRepository<Message,String> {
-    Page<Message> findAllByRoomId(String roomId, Pageable pageable);
-    Page<Message> findAllByRoomIdAndCreatedAtAfter(String roomId, LocalDateTime time, Pageable pageable);
+    Page<Message> findAllByRoomIdAndCreatedAtBetween(String roomId, LocalDateTime createdAt, LocalDateTime atTime, PageRequest pageRequest);
+
+    Long countByRoomIdAndCreatedAtBetween(String roomId, LocalDate targetDate, LocalDate plusDays);
 }

--- a/src/main/java/com/example/teamrocket/service/ChatServiceImpl.java
+++ b/src/main/java/com/example/teamrocket/service/ChatServiceImpl.java
@@ -266,7 +266,7 @@ public class ChatServiceImpl implements ChatService{
                 }
                 addPage = dayOfMessageCount%size == 0? dayOfMessageCount/size : dayOfMessageCount/size+1;
 
-                if(pastPage+addPage>=page){
+                if(pastPage+addPage > page){
                     break;
                 }else {
                     pastPage += addPage;
@@ -288,7 +288,7 @@ public class ChatServiceImpl implements ChatService{
                 dayOfMessageCount = dayOfMessages.get().getMessagesCount();
                 addPage = dayOfMessageCount%size == 0? dayOfMessageCount/size : dayOfMessageCount/size+1;
 
-                if(pastPage+addPage>=page){
+                if(pastPage+addPage>page){
                     break;
                 }else {
                     pastPage += addPage;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
DayOfMessages 의 카운트가 설정이 안되어 항상 0
getMessages에서 findByRoomIdAndCreatedAfter 로 되어 있어 여러 날짜의 메시지를 같이 받음
여러 날짜의 메시지를 같이 받아 시간 관계가 흐트러지는 현상 발생
날짜 변경 로직(페이지 체크) 이상(<= 로 체크 하는 오류)

**TO-BE**
DayOfMessages 의 카운트가 설정 부분 추가
getMessages에서 findByRoomIdAndCreatedBetween으로 변경 -> targetDay의 메시지만 받음
날짜 변경 로직 수정 (<로 수정)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 